### PR TITLE
fix: rename angular2 to angular-material

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const monorepoDefinitions = {
     '@angular/bazel',
     '@angular/language-service'
   ],
-  'angular2': [
+  'angular-material': [
     '@angular/material',
     '@angular/cdk',
     '@angular/material-experimental',


### PR DESCRIPTION
otherwise it is confusing because it is not "Angular 2" but modules related to Angular Material Design!