### PR TITLE
fix: remove `@angular/cli` from `angular`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const monorepoDefinitions = {
     '@angular/router',
     '@angular/common',
     '@angular/compiler',
-    '@angular/cli',
     '@angular/platform-server',
     '@angular/upgrade',
     '@angular/forms',


### PR DESCRIPTION
`@angular/cli` does not follow the exact same release cadence as @angular itself. I.e. even if the major version should match with other @angular libraries, like with `@angular/material` and `@angular/flex-layout` they don't necessarily match any version other than that.

Given the following statement in the docs:
> Note that we only support monorepo releases in which all modules contained in a single release have the same version number

The inclusion of `@angular/cli` thus should allegedly not be supported and it should thus not be considered as part of the regular Angular monorepo definition.

Would also mention that we have yet to get a functional Angular PR through Greenkeeper (even though there is a new update every week).