### PR TITLE
Add group for @angular/cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const monorepoDefinitions = {
     '@schematics/angular',
     '@schematics/schematics',
     '@schematics/update',
-    '@ngtools/webpack',
+    '@ngtools/webpack'
   ],
   'angular2': [
     '@angular/material',


### PR DESCRIPTION
Angular CLI is an integral part of Angular ecosystem but Angular can be used without it as well.  
However, each Angular CLI release consists of multiple packages (monorepo, just like Angular) and therefore these packages should be grouped in greenkeeper in a separate group.  
Currently every project that depends on one of the packages from [@angular-devkit](https://github.com/angular/angular-cli) scope will break upon every release.  
[Here](https://github.com/meltedspark/angular-builders/issues/136) is an example for that (having this issue every time).