### PR TITLE
Add group for NGXS

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,7 +480,7 @@ const monorepoDefinitions = {
     '@ngxs/storage-plugin',
     '@ngxs/store',
     '@ngxs/router-plugin',
-    '@ngxs/websocket-plugin',
+    '@ngxs/websocket-plugin'
   ],
   'polyfill-io-aot': [
     '@polyfill-io-aot/builder',

--- a/index.js
+++ b/index.js
@@ -473,6 +473,15 @@ const monorepoDefinitions = {
     '@material-ui/icons',
     '@material-ui/lab'
   ],
+  'ngxs': [
+    '@ngxs/devtools-plugin',
+    '@ngxs/form-plugin',
+    '@ngxs/logger-plugin',
+    '@ngxs/storage-plugin',
+    '@ngxs/store',
+    '@ngxs/router-plugin',
+    '@ngxs/websocket-plugin',
+  ],
   'polyfill-io-aot': [
     '@polyfill-io-aot/builder',
     '@polyfill-io-aot/builder-cli',


### PR DESCRIPTION
Add each dependency released in locked releases with the prefix `@ngxs/`, see docs at https://ngxs.gitbook.io/ngxs/.