### PR TITLE
feat: Add lodash group

### DIFF
--- a/index.js
+++ b/index.js
@@ -706,6 +706,10 @@ const monorepoDefinitions = {
     'diff-sequences',
     'jest-serializer'
   ],
+  'lodash': [
+    'lodash',
+    'lodash-es'
+  ],
   'material-ui': [
     '@material-ui/codemod',
     '@material-ui/core',


### PR DESCRIPTION
`lodash` and `lodash-es` are always kept in sync on npm. It's not uncommon to depend on both variants, using lodash for commonjs code and lodash-es for es2015 code so it makes sense to keep their updates in sync too.